### PR TITLE
Improve type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A small, dependency-free and strongly typed template engine.
 ## Features
 
 - **Light-weight**. Less than 1 KiB (actual size depends on imported functions).
-- **Dependency-free**. Only development dependencies are installed.
+- **Dependency-free**. Only bundled JavaScript files and TypeScript type declarations.
 - **Tree-shakable**. Only imported code comes to your bundle.
 - **ES Modules** and **CommonJS** syntax are supported.
 - Strongly typed with **TypeScript**. All types are exported alongside with the core functions.
@@ -46,22 +46,44 @@ import { hydrateText } from "hydrate-text";
 // CommonJS syntax
 const hydrateText = require("hydrate-text").hydrateText;
 
-// 'Hello, John Doe!'
-console.log(hydrateText("Hello, {username}!", { username: "John Doe" }));
+// 'Hello, John!'
+console.log(
+  hydrateText("Hello, {username}!", {
+    username: "John",
+  }),
+);
 
-// '/users/1'
+// '/users/42'
 console.log(
   hydrateText(
-    "/users/:userId",
-    { userId: 1 },
-    /*
-      If the interpolation options object is passed, `prefix` and `suffix`
-      become empty strings by default, so you don't have to set it manually for
-      unpaired markers.
-    */
+    "/users/:id",
+    { id: 42 },
     {
       prefix: ":",
+      suffix: "",
     },
+  ),
+);
+```
+
+TypeScript checks that all the variables defined in the given string are provided.
+
+```typescript
+console.log(
+  hydrateText(
+    "Hello, {username}!",
+    // No errors
+    {
+      username: "John",
+    },
+  ),
+);
+
+console.log(
+  hydrateText(
+    "Hello, {username}!",
+    // Error: `username` is missing
+    {},
   ),
 );
 ```
@@ -72,19 +94,16 @@ that returns `hydrateText` function as a result.
 ```typescript
 import { configureHydrateText } from "hydrate-text";
 
-const route = "/users/:userId";
-const routeWithCustomInterpolationOptions = "/users/(userId)";
-
 const hydrateRoute = configureHydrateText({ prefix: ":" });
 
-// '/users/2'
-console.log(hydrateRoute(route, { userId: 2 }));
+// '/users/42'
+console.log(hydrateRoute("/users/:id", { id: 42 }));
 
-// '/users/3'
+// '/users/42'
 console.log(
   hydrateRoute(
-    routeWithCustomInterpolationOptions,
-    { userId: 3 },
+    "/users/(id)",
+    { id: 42 },
     {
       prefix: "(",
       suffix: ")",
@@ -92,6 +111,8 @@ console.log(
   ),
 );
 ```
+
+Check out other [correct](./src/tests/index.types.ts) and [incorrect](./src/tests/index.errors.ts) usage examples.
 
 ## Installation
 
@@ -107,28 +128,28 @@ npm install hydrate-text
 yarn add hydrate-text
 ```
 
-## API
+## API (simplified)
 
 ```typescript
-type ValueType = string | number | boolean;
-
-type Variables = Record<string, ValueType>;
+type ValueType = string | boolean | number | bigint;
 
 interface InterpolationOptions {
-  prefix?: string;
-  suffix?: string;
+  prefix: string;
+  suffix: string;
 }
 
 function hydrateText(
   text: string,
-  variables?: Variables,
+  variables?: Record<string, ValueType>,
   interpolationOptions?: InterpolationOptions,
 ) {}
 
 function configureHydrateText(
-  interpolationOptions?: InterpolationOptions,
+  interpolationOptions: InterpolationOptions,
 ) => typeof hydrateText;
 ```
+
+Check out [types.ts](./src/types.ts) file for more information.
 
 ## Background
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrate-text",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A small, dependency-free and strongly typed template engine.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -29,12 +29,13 @@
     "url": "https://github.com/vasilii-kovalev/hydrate-text/issues"
   },
   "scripts": {
-    "tslint": "tsc",
+    "tslint": "tsc -p tsconfig.tslint.json",
+    "types": "check-dts",
     "eslint:check": "eslint --ext .ts src --color",
     "eslint:fix": "yarn eslint:check --fix",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "lint": "yarn tslint && yarn eslint:check && yarn prettier:check",
+    "lint": "yarn tslint && yarn types && yarn eslint:check && yarn prettier:check",
     "test": "jest",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -44,9 +45,11 @@
     "postversion": "git push && git push --tags"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.23",
-    "@typescript-eslint/eslint-plugin": "^4.28.1",
-    "@typescript-eslint/parser": "^4.28.1",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^16.3.1",
+    "@typescript-eslint/eslint-plugin": "^4.28.3",
+    "@typescript-eslint/parser": "^4.28.3",
+    "check-dts": "^0.5.3",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.23.4",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,11 @@
-import { InterpolationOptions } from "./types";
+import { DefaultPrefix, DefaultSuffix, InterpolationOptions } from "./types";
 
-const DEFAULT_INTERPOLATION_OPTIONS: InterpolationOptions = {
+const DEFAULT_INTERPOLATION_OPTIONS: InterpolationOptions<
+  DefaultPrefix,
+  DefaultSuffix
+> = {
   prefix: "{",
   suffix: "}",
 };
 
-const EMPTY_INTERPOLATION_OPTIONS: InterpolationOptions = {
-  prefix: "",
-  suffix: "",
-};
-
-export { DEFAULT_INTERPOLATION_OPTIONS, EMPTY_INTERPOLATION_OPTIONS };
+export { DEFAULT_INTERPOLATION_OPTIONS };

--- a/src/tests/index.errors.ts
+++ b/src/tests/index.errors.ts
@@ -1,0 +1,871 @@
+import { configureHydrateText, hydrateText } from "..";
+import { InterpolationOptions } from "../types";
+
+// Test Id: 538c85cdc1d3a5cf2ae0077f35e2637b
+// THROWS Expected 1-3 arguments, but got 0.
+hydrateText();
+
+// Test Id: c0b9f39290ad14fc77623be376dfaac2
+hydrateText(
+  "Hello, {username}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+);
+
+// Test Id: 58a3497c15b738181ef24073d786f7d9
+hydrateText("Hello, {username}!", {
+  // THROWS Type 'undefined' is not assignable to type 'ValueType'.
+  username: undefined,
+});
+
+// Test Id: fe4f227e4972390d9994afb20a31710e
+hydrateText("Hello, {username}!", {
+  // THROWS Type 'null' is not assignable to type 'ValueType'.
+  username: null,
+});
+
+// Test Id: fcab2ac81409176546edb81215cb36e3
+hydrateText("Hello, {username}!", {
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  USER_NAME: "John",
+});
+
+// Test Id: 4a15b9e240f46eba186c41d0f4664e96
+hydrateText("Hello, {username}!", {
+  username: "John",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  id: 42,
+});
+
+// Test Id: 432b9aa3ca520135b7c26882b8673e3a
+hydrateText(
+  "{firstName} {lastName}",
+  // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+  {
+    firstName: "John",
+  },
+);
+
+// Test Id: 126b3de3b75053ad49d66743f0c8f274
+hydrateText(
+  "{firstName} {lastName}",
+  // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+  {
+    lastName: "Doe",
+  },
+);
+
+// Test Id: ebd0a6612f82a8ed0031d9e059ef0615
+hydrateText(
+  "Active: {isActive}",
+  // THROWS not assignable to parameter of type 'Record<"isActive", ValueType>'.
+  {},
+);
+
+// Test Id: 03cb3b83ce958f1812469d094b6cdfae
+hydrateText("Active: {isActive}", {
+  // THROWS not assignable to parameter of type 'Record<"isActive", ValueType>'.
+  IS_ACTIVE: true,
+});
+
+// Test Id: 0b3f978b784258a5f01b26fc805f9c6e
+hydrateText("Active: {isActive}", {
+  isActive: true,
+  // THROWS not assignable to parameter of type 'Record<"isActive", ValueType>'.
+  id: 42,
+});
+
+// Test Id: b857c06caab24cdc873168a7aff76206
+hydrateText(
+  "Seconds: {seconds}",
+  // THROWS not assignable to parameter of type 'Record<"seconds", ValueType>'.
+  {},
+);
+
+// Test Id: 8e59d5c4458f80f22cc1bb24502ffc99
+hydrateText("Seconds: {seconds}", {
+  // THROWS not assignable to parameter of type 'Record<"seconds", ValueType>'.
+  SECONDS: 1_000_000,
+});
+
+// Test Id: d92b0750a9e4c02c76844b6744ee2573
+hydrateText("Seconds: {seconds}", {
+  seconds: 1_000_000,
+  // THROWS not assignable to parameter of type 'Record<"seconds", ValueType>'.
+  id: 42,
+});
+
+// Test Id: 306c99b7df15ec74284c55546c12a78f
+hydrateText(
+  "milliseconds: {milliseconds}",
+  // THROWS not assignable to parameter of type 'Record<"milliseconds", ValueType>'.
+  {},
+);
+
+// Test Id: 560e0c8cadd217f0ae283e385ae3c3af
+hydrateText("milliseconds: {milliseconds}", {
+  // THROWS not assignable to parameter of type 'Record<"milliseconds", ValueType>'.
+  MILLISECONDS: BigInt(9007199254740991),
+});
+
+// Test Id: 6f33cc35f75acf0daf730f245d5feb1b
+hydrateText("milliseconds: {milliseconds}", {
+  milliseconds: BigInt(9007199254740991),
+  // THROWS not assignable to parameter of type 'Record<"milliseconds", ValueType>'.
+  id: 42,
+});
+
+// Test Id: 3c30106444675dad01d6e308ea5298e5
+hydrateText(
+  "Hello, {{username}}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+);
+
+// Test Id: c8259b5a3f9405752fb2b709ed4fcbc9
+hydrateText("Hello, {{username}}!", {
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  USER_NAME: "John",
+});
+
+// Test Id: 600317192a267b2cd4f60e4b75e6ef1e
+hydrateText("Hello, {{username}}!", {
+  username: "John",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  id: 42,
+});
+
+// Test Id: 48795b7f39073c2426d99a61682ae5e7
+hydrateText(
+  "Hello, {username}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+  {},
+);
+
+// Test Id: a914816d90fad99932117e5456a21aaf
+hydrateText(
+  "Hello, {username}!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {},
+);
+
+// Test Id: f950113749305f4c4de6fd839b3b1369
+hydrateText(
+  "Hello, undefinedusernameundefined!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {},
+);
+
+// Test Id: 57e4397507e57f28d1e35f53434bbf37
+hydrateText(
+  "Hello, {username}!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {
+    prefix: "{",
+  },
+);
+
+// Test Id: ad24b69c8825b9b8e1589b644b2a210f
+hydrateText(
+  "Hello, {usernameundefined!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {
+    prefix: "{",
+  },
+);
+
+// Test Id: 09850c180d83e1aad23c5c71759bf52a
+hydrateText(
+  "Hello, {username}!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {
+    suffix: "}",
+  },
+);
+
+// Test Id: f2c4500d7b81642533ff7937559d4c1d
+hydrateText(
+  "Hello, undefinedusername}!",
+  {
+    username: "John",
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"{", "}">'.
+  {
+    suffix: "}",
+  },
+);
+
+// Test Id: 0f446ad7b42fc3094ab94e1941a60a7b
+hydrateText(
+  "Hello, {username}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+  {
+    prefix: "{",
+    suffix: "}",
+  },
+);
+
+// Test Id: 8e5661fb387b52bd5735f01a74973d96
+hydrateText(
+  "Hello, {username}!",
+  {
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    USER_NAME: "John",
+  },
+  {
+    prefix: "{",
+    suffix: "}",
+  },
+);
+
+// Test Id: 5742652cc6a193a17e668bb472a4ff00
+hydrateText(
+  "Hello, {username}!",
+  {
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: "{",
+    suffix: "}",
+  },
+);
+
+// Test Id: 70c1cba604a5c4ea8eaffc5c732c963b
+hydrateText(
+  "Hello, {{username}}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+  {
+    prefix: "{{",
+    suffix: "}}",
+  },
+);
+
+// Test Id: 6dc30b8715b383edc7da72be0f0c39bc
+hydrateText(
+  "Hello, {{username}}!",
+  {
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    USER_NAME: "John",
+  },
+  {
+    prefix: "{{",
+    suffix: "}}",
+  },
+);
+
+// Test Id: d1322ac7a747e94a5b2d1a6644261813
+hydrateText(
+  "Hello, {{username}}!",
+  {
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: "{{",
+    suffix: "}}",
+  },
+);
+
+// Test Id: 019d348956f4a1c679ac5412cd1abf60
+hydrateText(
+  "Hello, ${username}!",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+  {
+    prefix: "${",
+    suffix: "}",
+  },
+);
+
+// Test Id: 2b54c91bd343d5dc6844dbeb24600b21
+hydrateText(
+  "Hello, ${username}!",
+  {
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    USER_NAME: "John",
+  },
+  {
+    prefix: "${",
+    suffix: "}",
+  },
+);
+
+// Test Id: fd6dd1e7a9bf66cf8f0033bf0070e175
+hydrateText(
+  "Hello, ${username}!",
+  {
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: "${",
+    suffix: "}",
+  },
+);
+
+// Test Id: 12a32a5b6289285455b978bccb3160ca
+hydrateText(
+  ":firstName: :lastName:",
+  // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+  {},
+  {
+    prefix: ":",
+    suffix: ":",
+  },
+);
+
+// Test Id: 8fbb51b6cb87f8efaccbf1efe4e40792
+hydrateText(
+  ":firstName: :lastName:",
+  // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+  {
+    firstName: "John",
+  },
+  {
+    prefix: ":",
+    suffix: ":",
+  },
+);
+
+// Test Id: e27328ae9324195ae0d56f654846f8df
+hydrateText(
+  ":firstName: :lastName:",
+  // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+  {
+    lastName: "Doe",
+  },
+  {
+    prefix: ":",
+    suffix: ":",
+  },
+);
+
+// Test Id: 93b1ffde814c82af41354cbb408fe758
+hydrateText(
+  ":firstName: :lastName:",
+  {
+    firstName: "John",
+    lastName: "Doe",
+    // THROWS not assignable to parameter of type 'Record<"firstName" | "lastName", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: ":",
+    suffix: ":",
+  },
+);
+
+// Test Id: dca4da146c2a1a3151758d3a489cf625
+hydrateText(
+  "/user/:id",
+  // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+  {},
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: f24a61461b3a53a54c3f8be983a36e9b
+hydrateText(
+  "/user/:id",
+  {
+    // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+    ID: 42,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 23d33d2b73409e7e0ad781c6fe9d2f0f
+hydrateText(
+  "/user/:id",
+  {
+    id: 42,
+    // THROWS assignable to parameter of type 'Record<"id", ValueType>'.
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 2fc2c3180c1d6d00f46b61de4da70490
+hydrateText(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {},
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 3cd3cb9b568dfc4278706a1b9a3569be
+hydrateText(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    id: 42,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 77fe5fa145abed7db81f53a7bcfef672
+hydrateText(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: c2fc6a631abb5bc533ffa79ce8c424d3
+hydrateText(
+  "/user/:id:username",
+  {
+    id: 42,
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+    isActive: true,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: f8c0e7dfd3c704d8d2cbf87ea79eb7f3
+hydrateText(
+  "username: - Software Engineer",
+  // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+  {},
+  {
+    prefix: "",
+    suffix: ":",
+  },
+);
+
+// Test Id: 5d64c1ca0bd22edf1fbd4ee4082851aa
+hydrateText(
+  "username: - Software Engineer",
+  {
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    USER_NAME: "John",
+  },
+  {
+    prefix: "",
+    suffix: ":",
+  },
+);
+
+// Test Id: 2799c5011a9c8c8ce494f684c2363a62
+hydrateText(
+  "username: - Software Engineer",
+  {
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: "",
+    suffix: ":",
+  },
+);
+
+// Test Id: f15576c900a23aece67b8790f75d5c5b
+hydrateText(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {},
+  {
+    prefix: "",
+    suffix: "",
+  },
+);
+
+// Test Id: b4395ed60e6df24fcaf8c64a73506564
+hydrateText(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {
+    u: "{U}",
+  },
+  {
+    prefix: "",
+    suffix: "",
+  },
+);
+
+// Test Id: 5301902ac4bc03f4d189138ff78aa7dd
+hydrateText(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {
+    u: "{U}",
+    s: "<S>",
+  },
+  {
+    prefix: "",
+    suffix: "",
+  },
+);
+
+// Test Id: 629e103c775ff70bf24e4ce8d895dfc6
+hydrateText(
+  "user",
+  {
+    u: "{U}",
+    s: "<S>",
+    e: "(E)",
+    r: "[R]",
+    // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+    x: "-X-",
+  },
+  {
+    prefix: "",
+    suffix: "",
+  },
+);
+
+// Test Id: 62f126044c723f6c33cf0b3e4b49cd1e
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {},
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 9e145f684808799c252a3b9dcc83b0a8
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    id: 42,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 1d183b36f9bebd6611286603ac6ea03f
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: b4b07415edd487c532b4390271acba48
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  {
+    id: 42,
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+    isActive: true,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 262e61bc664f60e8aeb5b3112da513a1
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  {
+    id: 42,
+    username: "John",
+  },
+  {
+    prefix: ":",
+    // THROWS Type '""' is not assignable to type '"/"'.
+    suffix: "",
+  },
+);
+
+// Test Id: bea0800f7db8cac5f8bc89cf890f8c98
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {},
+  {
+    prefix: ":",
+    suffix: "",
+  } as unknown as InterpolationOptions<":", "/">,
+);
+
+// Test Id: 210ad704a05d205283be9bd851ee9da8
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    id: 42,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  } as unknown as InterpolationOptions<":", "/">,
+);
+
+// Test Id: b7e74a2db86e541d3dad8fdb361b73d5
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  } as unknown as InterpolationOptions<":", "/">,
+);
+
+// Test Id: cd001933ed729c3509d23b847c266c75
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  {
+    id: 42,
+    username: "John",
+    // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+    isActive: true,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  } as unknown as InterpolationOptions<":", "/">,
+);
+
+const hydrateRoute = configureHydrateText({
+  prefix: ":",
+  suffix: "",
+});
+
+// Test Id: 318796ae08e53e90f10ed2d5dfa737f6
+// THROWS Expected 1-3 arguments, but got 0.
+hydrateRoute();
+
+// Test Id: 4f4fd053c4fea88c9b5986fa6e78571c
+hydrateRoute(
+  "/user/:id",
+  // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+  {},
+);
+
+// Test Id: bbd65218fd0703080e2709b24364df2b
+hydrateRoute("/user/:id", {
+  // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+  ID: 42,
+});
+
+// Test Id: 6cd689e4ed7bc823683d994ebb393757
+hydrateRoute("/user/:id", {
+  id: 42,
+  // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+  username: "John",
+});
+
+// Test Id: e95f207e9eaa2b21feaff941f6cd7038
+hydrateRoute(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {},
+);
+
+// Test Id: ea721ecccc2112a68ad21d47d240777a
+hydrateRoute(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    username: "John",
+  },
+);
+
+// Test Id: 38bb62fb4be465bc27a6bd5c0299bb52
+hydrateRoute(
+  "/user/:id:username",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  {
+    id: 42,
+  },
+);
+
+// Test Id: 8a1ca67b89dab1a7bdbd3a1cd1b0d1ed
+hydrateRoute("/user/:id:username", {
+  id: 42,
+  username: "John",
+  // THROWS not assignable to parameter of type 'Record<"username" | "id", ValueType>'.
+  isActive: true,
+});
+
+// Test Id: 92b41b81af940608db31d005741a6c6c
+hydrateRoute(
+  "/user/(id)",
+  // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+  {},
+  {
+    prefix: "(",
+    suffix: ")",
+  },
+);
+
+// Test Id: 823c18ebf1669a4d28a85355c563c3c3
+hydrateRoute(
+  "/user/(id)",
+  {
+    // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+    ID: 42,
+  },
+  {
+    prefix: "(",
+    suffix: ")",
+  },
+);
+
+// Test Id: 5e49f161e48aa13c6360ca4cc3bf535d
+hydrateRoute(
+  "/user/(id)",
+  {
+    id: 42,
+    // THROWS not assignable to parameter of type 'Record<"id", ValueType>'.
+    username: "John",
+  },
+  {
+    prefix: "(",
+    suffix: ")",
+  },
+);
+
+// Test Id: d7e87174c35b0a36b6edf7683372eccd
+hydrateRoute(
+  "/user/(id",
+  {
+    id: 42,
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<"(", "">'.
+  {
+    prefix: "(",
+  },
+);
+
+// Test Id: dea3dc9c2eed148b9535cbdde3835a43
+hydrateRoute(
+  "/user/(idundefined",
+  {
+    // THROWS not assignable to parameter of type 'Record<"idundefined", ValueType>'.
+    id: 42,
+  },
+  {
+    prefix: "(",
+  },
+);
+
+// Test Id: 0715c3ceaa37e39b9b2d9ebf4c5b6c76
+hydrateRoute(
+  "/user/:id)",
+  {
+    id: 42,
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<":", ")">'.
+  {
+    suffix: ")",
+  },
+);
+
+// Test Id: 844652a9cccbb162634eedc03161bcae
+hydrateRoute(
+  "/user/undefinedid)",
+  {
+    id: 42,
+  },
+  // THROWS not assignable to parameter of type 'InterpolationOptions<":", ")">'.
+  {
+    suffix: ")",
+  },
+);
+
+const replaceLetters = configureHydrateText({
+  prefix: "",
+  suffix: "",
+});
+
+// Test Id: bf02495a5023dea7a9f35e7849b2ba1c
+replaceLetters(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {},
+);
+
+// Test Id: f4460942636b17ae0beaa197dc5cb8ab
+replaceLetters(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {
+    u: "{U}",
+  },
+);
+
+// Test Id: e90c03a47d7cbc56fb2f5dd44bebe162
+replaceLetters(
+  "user",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  {
+    u: "{U}",
+    s: "<S>",
+  },
+);
+
+// Test Id: 6001dba4f00a338fc6409af6788b0879
+replaceLetters("user", {
+  u: "{U}",
+  s: "<S>",
+  e: "(E)",
+  r: "[R]",
+  // THROWS not assignable to parameter of type 'Record<"u" | "s" | "e" | "r", ValueType>'.
+  x: "-X-",
+});
+
+// THROWS Type instantiation is excessively deep and possibly infinite.
+replaceLetters("some very, very long text", {});

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,189 +1,2410 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// import crypto from "crypto";
+
 import { configureHydrateText, hydrateText } from "..";
-import { HydrateText, Variables } from "../types";
+import { InterpolationOptions } from "../types";
 
-describe("hydrateText", () => {
-  describe("default interpolation options", () => {
-    const textWithoutVariables = "Simple text";
-    const variables: Variables = {
-      0: "mr.",
-      1: "miss",
-      age: 2,
-      alive: true,
-      user1: "John",
-      user2: "Sarah",
-    };
+// Inspired by: https://stackoverflow.com/a/11869589/11293963
+// const getHash = (string: string) =>
+//   crypto.createHash("md5").update(string).digest("hex");
 
-    it(`should keep "textWithoutVariables" as is
-    if "variables" is not provided`, () => {
-      const resultText = hydrateText(textWithoutVariables);
-
-      expect(resultText).toBe(textWithoutVariables);
-    });
-
-    it(`should keep "textWithoutVariables" as is
-    if "variables" is provided`, () => {
-      const resultText = hydrateText(textWithoutVariables, variables);
-
-      expect(resultText).toBe(textWithoutVariables);
-    });
-
-    const textWithVariables = "Hello, {0} {user1} and {1} {user2}";
-
-    it(`should keep "textWithVariables" as is
-    if "variables" is not provided`, () => {
-      const resultText = hydrateText(textWithVariables);
-
-      expect(resultText).toBe(textWithVariables);
-    });
-
-    it(`should replace correct variables in "textWithVariables"
-    if "variables" is provided`, () => {
-      const resultText = hydrateText(textWithVariables, variables);
-
-      expect(resultText).toBe("Hello, mr. John and miss Sarah");
-    });
-
-    const textWithNoise = "Hello, {0} {{user1}} and {{1}} {user2}";
-
-    it(`should keep "textWithNoise" as is
-    if "variables" is not provided`, () => {
-      const resultText = hydrateText(textWithNoise);
-
-      expect(resultText).toBe(textWithNoise);
-    });
-
-    it(`should replace correct variables in "textWithNoise"
-    if "variables" is provided`, () => {
-      const resultText = hydrateText(textWithNoise, variables);
-
-      expect(resultText).toBe("Hello, mr. {John} and {miss} Sarah");
-    });
-  });
-
-  describe("custom interpolation options", () => {
-    const oneVariable: Variables = { variableName: "hello" };
-    const replaceRouteVariables: HydrateText = (text, variables) =>
-      hydrateText(text, variables, { prefix: ":" });
-
-    it('should keep "routeHome" as is', () => {
-      const routeHome = "/";
-
-      const resultText = replaceRouteVariables(routeHome, oneVariable);
-
-      expect(resultText).toBe(routeHome);
-    });
-
-    it('should keep "routeWithoutVariables" as is', () => {
-      const routeWithoutVariables = "/some/route";
-
-      const resultText = replaceRouteVariables(
-        routeWithoutVariables,
-        oneVariable,
-      );
-
-      expect(resultText).toBe(routeWithoutVariables);
-    });
-
-    it('should replace correct variables in "routeWithVariable"', () => {
-      const routeWithVariable = "/some/route/:variableName";
-
-      const resultText = replaceRouteVariables(routeWithVariable, oneVariable);
-
-      expect(resultText).toBe("/some/route/hello");
-    });
-
-    const routeWithVariables = "/some/route/:variableName/:variableId";
-
-    it('should replace correct variables in "routeWithVariables"', () => {
-      const twoVariables: Variables = {
-        variableName: "hello",
-        variableId: 1,
-      };
-
-      const resultText = replaceRouteVariables(
-        routeWithVariables,
-        twoVariables,
-      );
-
-      expect(resultText).toBe("/some/route/hello/1");
-    });
-
-    it("should replace variables if they contain nullish values", () => {
-      // Check a fallback if types don't work, e.g. in JavaScript files.
-      const variablesWithUndefinedAndNull: Variables = {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        variableId: undefined as unknown as any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        variableName: null as any,
-      };
-
-      const resultText = replaceRouteVariables(
-        routeWithVariables,
-        variablesWithUndefinedAndNull,
-      );
-
-      expect(resultText).toBe("/some/route/null/undefined");
-    });
-
-    const pangram = "The quick brown fox jumps over the lazy dog";
-
-    it(`should replace a variable
-    if prefix and suffix are empty strings (the variable is a word)`, () => {
-      const resultText = hydrateText(
-        pangram,
-        { fox: "FOX" },
-        { prefix: "", suffix: "" },
-      );
-
-      expect(resultText).toBe("The quick brown FOX jumps over the lazy dog");
-    });
-
-    it(`should replace a variable
-    if prefix and suffix are empty strings (the variable is a letter)`, () => {
-      const resultText = hydrateText(
-        pangram,
-        { e: "(E)" },
-        { prefix: "", suffix: "" },
-      );
-
-      expect(resultText).toBe(
-        "Th(E) quick brown fox jumps ov(E)r th(E) lazy dog",
-      );
-    });
-
-    it(`should replace a variable
-    if the interpolation options object is empty`, () => {
-      const resultText = hydrateText(pangram, { e: "(E)" }, {});
-
-      expect(resultText).toBe(
-        "Th(E) quick brown fox jumps ov(E)r th(E) lazy dog",
-      );
-    });
-  });
+const hydrateRoute = configureHydrateText({
+  prefix: ":",
+  suffix: "",
 });
 
-describe("configureHydrateText", () => {
-  const oneVariable: Variables = { variableName: "hello" };
-  const replaceRouteVariables = configureHydrateText({ prefix: ":" });
+const replaceLetters = configureHydrateText({
+  prefix: "",
+  suffix: "",
+});
 
-  it(`should replace correct variables in "routeWithVariable"
-  with custom interpolation options set in configureHydrateText`, () => {
-    const routeWithVariable = "/some/route/:variableName";
+test("Positive test case: e3d1bd7920d571fae01eb16c3b8343ba", () => {
+  // console.log(getHash(`hydrateText("")`));
+  const resultText = hydrateText("");
 
-    const resultText = replaceRouteVariables(routeWithVariable, oneVariable);
+  expect(resultText).toBe("");
+});
 
-    expect(resultText).toBe("/some/route/hello");
+test("Positive test case: 18d6dbe5774751098a4a74c590ef53c0", () => {
+  // console.log(getHash(`hydrateText("Hello World!")`));
+  const resultText = hydrateText("Hello World!");
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: 4260b34d10b016b41c1b7509cbe699fd", () => {
+  // console.log(getHash(`hydrateText("Hello, {username}!")`));
+  const resultText = hydrateText("Hello, {username}!");
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Positive test case: 2af2fc130be13f625c9c5adafd808471", () => {
+  // console.log(getHash(`hydrateText("", {})`));
+  const resultText = hydrateText("", {});
+
+  expect(resultText).toBe("");
+});
+
+test("Positive test case: c4bb40eefc35e88d5779a86a99560386", () => {
+  // console.log(getHash(`hydrateText("Hello World!", {})`));
+  const resultText = hydrateText("Hello World!", {});
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: 42301541eb3fc4573221705d2113b799", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!", {
+  //   username: "John",
+  // })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!", {
+    username: "John",
   });
 
-  it(`should replace correct variables in "routeWithVariable"
-  with interpolation options set in replaceRouteVariables`, () => {
-    const routeWithVariable = "/some/route/(variableName)";
+  expect(resultText).toBe("Hello, John!");
+});
 
-    const resultText = replaceRouteVariables(routeWithVariable, oneVariable, {
+test("Positive test case: 383c38f885d84ebd652223325669afd1", () => {
+  // console.log(
+  //   getHash(`hydrateText("{firstName} {lastName}", {
+  //     firstName: "John",
+  //     lastName: "Doe",
+  //   })`),
+  // );
+  const resultText = hydrateText("{firstName} {lastName}", {
+    firstName: "John",
+    lastName: "Doe",
+  });
+
+  expect(resultText).toBe("John Doe");
+});
+
+test("Positive test case: 4fadf44d831fc988cf92fa78c54e8b5e", () => {
+  // console.log(
+  //   getHash(`hydrateText("Active: {isActive}", {
+  //     isActive: true,
+  //   })`),
+  // );
+  const resultText = hydrateText("Active: {isActive}", {
+    isActive: true,
+  });
+
+  expect(resultText).toBe("Active: true");
+});
+
+test("Positive test case: b3178c3166956e50643e4267c312607e", () => {
+  // console.log(
+  //   getHash(`hydrateText("Seconds: {seconds}", {
+  //     seconds: 1_000_000,
+  //   })`),
+  // );
+  const resultText = hydrateText("Seconds: {seconds}", {
+    seconds: 1_000_000,
+  });
+
+  expect(resultText).toBe("Seconds: 1000000");
+});
+
+test("Positive test case: 4e55ba820ff0a4c8e2a7c925e7693c2b", () => {
+  // console.log(
+  //   getHash(`hydrateText("milliseconds: {milliseconds}", {
+  //     milliseconds: BigInt(9007199254740991),
+  //   })`),
+  // );
+  const resultText = hydrateText("milliseconds: {milliseconds}", {
+    milliseconds: BigInt(9007199254740991),
+  });
+
+  expect(resultText).toBe("milliseconds: 9007199254740991");
+});
+
+test("Positive test case: af9b1b362e6dee5ed69f10bb7e397c95", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {{username}}!", {
+  //     username: "John",
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {{username}}!", {
+    username: "John",
+  });
+
+  expect(resultText).toBe("Hello, {John}!");
+});
+
+test("Positive test case: 18cd8d6e9f8325289789633dfe77000f", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "{",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      username: "John",
+    },
+    {
+      prefix: "{",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Positive test case: 01f2345edad7d94b6f753581a2b17a27", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {{username}}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "{{",
+  //       suffix: "}}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {{username}}!",
+    {
+      username: "John",
+    },
+    {
+      prefix: "{{",
+      suffix: "}}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Positive test case: 4a43c157fab840b304b4748a07267f6b", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, \${username}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "\${",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, ${username}!",
+    {
+      username: "John",
+    },
+    {
+      prefix: "${",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Positive test case: ab65a82ede035969c3b775a4c12c4532", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     ":firstName: :lastName:",
+  //     {
+  //       firstName: "John",
+  //       lastName: "Doe",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    ":firstName: :lastName:",
+    {
+      firstName: "John",
+      lastName: "Doe",
+    },
+    {
+      prefix: ":",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("John Doe");
+});
+
+test("Positive test case: 92b4b1b542a73f57476f371932510d1a", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id",
+    {
+      id: 42,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Positive test case: c14763e95536731399382dee040a5602", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id:username",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id:username",
+    {
+      id: 42,
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42John");
+});
+
+test("Positive test case: 7fa77b7792d13b8567c8e9a6c82195dd", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "username: - Software Engineer",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "username: - Software Engineer",
+    {
+      username: "John",
+    },
+    {
+      prefix: "",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("John - Software Engineer");
+});
+
+test("Positive test case: 78a37c77100f73d67498ae4ff83ddf53", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //       s: "<S>",
+  //       e: "(E)",
+  //       r: "[R]",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "user",
+    {
+      u: "{U}",
+      s: "<S>",
+      e: "(E)",
+      r: "[R]",
+    },
+    {
+      prefix: "",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("{U}<S>(E)[R]");
+});
+
+test("Positive test case: 5eaa48bee5ae430cbab0ff3746c27a53", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     } as unknown as InterpolationOptions<":", "/">,
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    {
+      id: 42,
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    } as unknown as InterpolationOptions<":", "/">,
+  );
+
+  expect(resultText).toBe("/user/42/John/");
+});
+
+test("Positive test case: f73fa2573b43438a2ac9a52706e2604b", () => {
+  // console.log(getHash(`hydrateText("Hello World!" as string)`));
+  const resultText = hydrateText("Hello World!" as string);
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: 707af50942d29b5c46fe7d0c0b381b3c", () => {
+  // console.log(getHash(`hydrateText("Hello World!" as string, {})`));
+  const resultText = hydrateText("Hello World!" as string, {});
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: e37d01f00d8432804eeaa6add2cc7a9a", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello World!" as string, {
+  //   username: "John",
+  // })`),
+  // );
+  const resultText = hydrateText("Hello World!" as string, {
+    username: "John",
+  });
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: bf580c9c905ee5f255a28e6b850347f9", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!" as string, {
+  //     username: "John",
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!" as string, {
+    username: "John",
+  });
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Positive test case: cdcdac2c1b868bc728472cd6cbba271f", () => {
+  // console.log(getHash(`hydrateRoute("")`));
+  const resultText = hydrateRoute("");
+
+  expect(resultText).toBe("");
+});
+
+test("Positive test case: d666a945c62ffbb4dfbefa886e1f9b7d", () => {
+  // console.log(getHash(`hydrateRoute("Hello World!")`));
+  const resultText = hydrateRoute("Hello World!");
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: 176fa7cbde3554852920b8117ffd06ec", () => {
+  // console.log(getHash(`hydrateRoute("Hello, {username}!")`));
+  const resultText = hydrateRoute("Hello, {username}!");
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Positive test case: df846302df158f3abb4a2cdb8ab14af9", () => {
+  // console.log(getHash(`hydrateRoute("", {})`));
+  const resultText = hydrateRoute("", {});
+
+  expect(resultText).toBe("");
+});
+
+test("Positive test case: 6e3983ff1c1769fc3fce68ad636ed0e1", () => {
+  // console.log(getHash(`hydrateRoute("Hello World!", {})`));
+  const resultText = hydrateRoute("Hello World!", {});
+
+  expect(resultText).toBe("Hello World!");
+});
+
+test("Positive test case: 387e00c55433a77cb30054261f8dbd70", () => {
+  // console.log(getHash(`hydrateRoute("/user/:id")`));
+  const resultText = hydrateRoute("/user/:id");
+
+  expect(resultText).toBe("/user/:id");
+});
+
+test("Positive test case: e39e3bddb6906f26f5e28be34a529d50", () => {
+  // console.log(
+  //   getHash(`hydrateRoute("/user/:id", {
+  //   id: 42,
+  // })`),
+  // );
+  const resultText = hydrateRoute("/user/:id", {
+    id: 42,
+  });
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Positive test case: 4fc02ff80bd4bb296c9a06506040314a", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(id)",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "(",
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(id)",
+    {
+      id: 42,
+    },
+    {
       prefix: "(",
       suffix: ")",
-    });
+    },
+  );
 
-    expect(resultText).toBe("/some/route/hello");
+  expect(resultText).toBe("/user/42");
+});
+
+test("Positive test case: a50d6c6a7ee526b764bfd112c69ec773", () => {
+  // console.log(
+  //   getHash(`replaceLetters("user", {
+  //     u: "{U}",
+  //     s: "<S>",
+  //     e: "(E)",
+  //     r: "[R]",
+  //   })`),
+  // );
+  const resultText = replaceLetters("user", {
+    u: "{U}",
+    s: "<S>",
+    e: "(E)",
+    r: "[R]",
   });
+
+  expect(resultText).toBe("{U}<S>(E)[R]");
+});
+
+test("Positive test case: 848097af194354e7e59c3a06a33f8844", () => {
+  // console.log(getHash(`replaceLetters("some very, very long text")`));
+  const resultText = replaceLetters("Some very, very long text");
+
+  expect(resultText).toBe("Some very, very long text");
+});
+
+test("Negative test case: 538c85cdc1d3a5cf2ae0077f35e2637b", () => {
+  // console.log(getHash(`hydrateText()`));
+  // @ts-expect-error
+  const resultText = hydrateText();
+
+  expect(resultText).toBeUndefined();
+});
+
+test("Negative test case: c0b9f39290ad14fc77623be376dfaac2", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //   "Hello, {username}!",
+  //   {},
+  // )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: 58a3497c15b738181ef24073d786f7d9", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!", {
+  //     username: undefined,
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!", {
+    // @ts-expect-error
+    username: undefined,
+  });
+
+  expect(resultText).toBe("Hello, undefined!");
+});
+
+test("Negative test case: fe4f227e4972390d9994afb20a31710e", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!", {
+  //     username: null,
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!", {
+    // @ts-expect-error
+    username: null,
+  });
+
+  expect(resultText).toBe("Hello, null!");
+});
+
+test("Negative test case: fcab2ac81409176546edb81215cb36e3", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!", {
+  //     USER_NAME: "John",
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!", {
+    // @ts-expect-error
+    USER_NAME: "John",
+  });
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: 4a15b9e240f46eba186c41d0f4664e96", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {username}!", {
+  //     username: "John",
+  //     id: 42,
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {username}!", {
+    username: "John",
+    // @ts-expect-error
+    id: 42,
+  });
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 432b9aa3ca520135b7c26882b8673e3a", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "{firstName} {lastName}",
+  //     {
+  //       firstName: "John",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "{firstName} {lastName}",
+    // @ts-expect-error
+    {
+      firstName: "John",
+    },
+  );
+
+  expect(resultText).toBe("John {lastName}");
+});
+
+test("Negative test case: 126b3de3b75053ad49d66743f0c8f274", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "{firstName} {lastName}",
+  //     {
+  //       lastName: "Doe",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "{firstName} {lastName}",
+    // @ts-expect-error
+    {
+      lastName: "Doe",
+    },
+  );
+
+  expect(resultText).toBe("{firstName} Doe");
+});
+
+test("Negative test case: ebd0a6612f82a8ed0031d9e059ef0615", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Active: {isActive}",
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Active: {isActive}",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Active: {isActive}");
+});
+
+test("Negative test case: 03cb3b83ce958f1812469d094b6cdfae", () => {
+  // console.log(
+  //   getHash(`hydrateText("Active: {isActive}", {
+  //     IS_ACTIVE: true,
+  //   })`),
+  // );
+  const resultText = hydrateText("Active: {isActive}", {
+    // @ts-expect-error
+    IS_ACTIVE: true,
+  });
+
+  expect(resultText).toBe("Active: {isActive}");
+});
+
+test("Negative test case: 0b3f978b784258a5f01b26fc805f9c6e", () => {
+  // console.log(
+  //   getHash(`hydrateText("Active: {isActive}", {
+  //     isActive: true,
+  //     id: 42,
+  //   })`),
+  // );
+  const resultText = hydrateText("Active: {isActive}", {
+    isActive: true,
+    // @ts-expect-error
+    id: 42,
+  });
+
+  expect(resultText).toBe("Active: true");
+});
+
+test("Negative test case: b857c06caab24cdc873168a7aff76206", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Seconds: {seconds}",
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Seconds: {seconds}",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Seconds: {seconds}");
+});
+
+test("Negative test case: 8e59d5c4458f80f22cc1bb24502ffc99", () => {
+  // console.log(
+  //   getHash(`hydrateText("Seconds: {seconds}", {
+  //     SECONDS: 1_000_000,
+  //   })`),
+  // );
+  const resultText = hydrateText("Seconds: {seconds}", {
+    // @ts-expect-error
+    SECONDS: 1_000_000,
+  });
+
+  expect(resultText).toBe("Seconds: {seconds}");
+});
+
+test("Negative test case: d92b0750a9e4c02c76844b6744ee2573", () => {
+  // console.log(
+  //   getHash(`hydrateText("Seconds: {seconds}", {
+  //     seconds: 1_000_000,
+  //     id: 42,
+  //   })`),
+  // );
+  const resultText = hydrateText("Seconds: {seconds}", {
+    seconds: 1_000_000,
+    // @ts-expect-error
+    id: 42,
+  });
+
+  expect(resultText).toBe("Seconds: 1000000");
+});
+
+test("Negative test case: 306c99b7df15ec74284c55546c12a78f", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "milliseconds: {milliseconds}",
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "milliseconds: {milliseconds}",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("milliseconds: {milliseconds}");
+});
+
+test("Negative test case: 560e0c8cadd217f0ae283e385ae3c3af", () => {
+  // console.log(
+  //   getHash(`hydrateText("milliseconds: {milliseconds}", {
+  //     MILLISECONDS: BigInt(9007199254740991),
+  //   })`),
+  // );
+  const resultText = hydrateText("milliseconds: {milliseconds}", {
+    // @ts-expect-error
+    MILLISECONDS: BigInt(9007199254740991),
+  });
+
+  expect(resultText).toBe("milliseconds: {milliseconds}");
+});
+
+test("Negative test case: 6f33cc35f75acf0daf730f245d5feb1b", () => {
+  // console.log(
+  //   getHash(`hydrateText("milliseconds: {milliseconds}", {
+  //     milliseconds: BigInt(9007199254740991),
+  //     id: 42,
+  //   })`),
+  // );
+  const resultText = hydrateText("milliseconds: {milliseconds}", {
+    milliseconds: BigInt(9007199254740991),
+    // @ts-expect-error
+    id: 42,
+  });
+
+  expect(resultText).toBe("milliseconds: 9007199254740991");
+});
+
+test("Negative test case: 3c30106444675dad01d6e308ea5298e5", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {{username}}!",
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {{username}}!",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Hello, {{username}}!");
+});
+
+test("Negative test case: c8259b5a3f9405752fb2b709ed4fcbc9", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {{username}}!", {
+  //     USER_NAME: "John",
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {{username}}!", {
+    // @ts-expect-error
+    USER_NAME: "John",
+  });
+
+  expect(resultText).toBe("Hello, {{username}}!");
+});
+
+test("Negative test case: 600317192a267b2cd4f60e4b75e6ef1e", () => {
+  // console.log(
+  //   getHash(`hydrateText("Hello, {{username}}!", {
+  //     username: "John",
+  //     id: 42,
+  //   })`),
+  // );
+  const resultText = hydrateText("Hello, {{username}}!", {
+    username: "John",
+    // @ts-expect-error
+    id: 42,
+  });
+
+  expect(resultText).toBe("Hello, {John}!");
+});
+
+test("Negative test case: 48795b7f39073c2426d99a61682ae5e7", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {},
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    // @ts-expect-error
+    {},
+    {},
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: a914816d90fad99932117e5456a21aaf", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: f950113749305f4c4de6fd839b3b1369", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, undefinedusernameundefined!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, undefinedusernameundefined!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 57e4397507e57f28d1e35f53434bbf37", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "{",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {
+      prefix: "{",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: ad24b69c8825b9b8e1589b644b2a210f", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {usernameundefined!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "{",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {usernameundefined!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {
+      prefix: "{",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 09850c180d83e1aad23c5c71759bf52a", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: f2c4500d7b81642533ff7937559d4c1d", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, undefinedusername}!",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, undefinedusername}!",
+    {
+      username: "John",
+    },
+    // @ts-expect-error
+    {
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 0f446ad7b42fc3094ab94e1941a60a7b", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {},
+  //     {
+  //       prefix: "{",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "{",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: 8e5661fb387b52bd5735f01a74973d96", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       USER_NAME: "John",
+  //     },
+  //     {
+  //       prefix: "{",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      // @ts-expect-error
+      USER_NAME: "John",
+    },
+    {
+      prefix: "{",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {username}!");
+});
+
+test("Negative test case: 5742652cc6a193a17e668bb472a4ff00", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {username}!",
+  //     {
+  //       username: "John",
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "{",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {username}!",
+    {
+      username: "John",
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: "{",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 70c1cba604a5c4ea8eaffc5c732c963b", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {{username}}!",
+  //     {},
+  //     {
+  //       prefix: "{{",
+  //       suffix: "}}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {{username}}!",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "{{",
+      suffix: "}}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {{username}}!");
+});
+
+test("Negative test case: 6dc30b8715b383edc7da72be0f0c39bc", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {{username}}!",
+  //     {
+  //       USER_NAME: "John",
+  //     },
+  //     {
+  //       prefix: "{{",
+  //       suffix: "}}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {{username}}!",
+    {
+      // @ts-expect-error
+      USER_NAME: "John",
+    },
+    {
+      prefix: "{{",
+      suffix: "}}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, {{username}}!");
+});
+
+test("Negative test case: d1322ac7a747e94a5b2d1a6644261813", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, {{username}}!",
+  //     {
+  //       username: "John",
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "{{",
+  //       suffix: "}}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, {{username}}!",
+    {
+      username: "John",
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: "{{",
+      suffix: "}}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 019d348956f4a1c679ac5412cd1abf60", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, \${username}!",
+  //     {},
+  //     {
+  //       prefix: "\${",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, ${username}!",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "${",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, ${username}!");
+});
+
+test("Negative test case: 2b54c91bd343d5dc6844dbeb24600b21", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, \${username}!",
+  //     {
+  //       USER_NAME: "John",
+  //     },
+  //     {
+  //       prefix: "\${",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, ${username}!",
+    {
+      // @ts-expect-error
+
+      USER_NAME: "John",
+    },
+    {
+      prefix: "${",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, ${username}!");
+});
+
+test("Negative test case: fd6dd1e7a9bf66cf8f0033bf0070e175", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "Hello, \${username}!",
+  //     {
+  //       username: "John",
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "\${",
+  //       suffix: "}",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "Hello, ${username}!",
+    {
+      username: "John",
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: "${",
+      suffix: "}",
+    },
+  );
+
+  expect(resultText).toBe("Hello, John!");
+});
+
+test("Negative test case: 12a32a5b6289285455b978bccb3160ca", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     ":firstName: :lastName:",
+  //     {},
+  //     {
+  //       prefix: ":",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    ":firstName: :lastName:",
+    // @ts-expect-error
+    {},
+    {
+      prefix: ":",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe(":firstName: :lastName:");
+});
+
+test("Negative test case: 8fbb51b6cb87f8efaccbf1efe4e40792", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     ":firstName: :lastName:",
+  //     {
+  //       firstName: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    ":firstName: :lastName:",
+    // @ts-expect-error
+    {
+      firstName: "John",
+    },
+    {
+      prefix: ":",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("John :lastName:");
+});
+
+test("Negative test case: e27328ae9324195ae0d56f654846f8df", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     ":firstName: :lastName:",
+  //     {
+  //       lastName: "Doe",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    ":firstName: :lastName:",
+    // @ts-expect-error
+    {
+      lastName: "Doe",
+    },
+    {
+      prefix: ":",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe(":firstName: Doe");
+});
+
+test("Negative test case: 93b1ffde814c82af41354cbb408fe758", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     ":firstName: :lastName:",
+  //     {
+  //       firstName: "John",
+  //       lastName: "Doe",
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    ":firstName: :lastName:",
+    {
+      firstName: "John",
+      lastName: "Doe",
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: ":",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("John Doe");
+});
+
+test("Negative test case: dca4da146c2a1a3151758d3a489cf625", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id",
+  //     {},
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id",
+    // @ts-expect-error
+    {},
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id");
+});
+
+test("Negative test case: f24a61461b3a53a54c3f8be983a36e9b", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id",
+  //     {
+  //       ID: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id",
+    {
+      // @ts-expect-error
+      ID: 42,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id");
+});
+
+test("Negative test case: 23d33d2b73409e7e0ad781c6fe9d2f0f", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id",
+    {
+      id: 42,
+      // @ts-expect-error
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Negative test case: 2fc2c3180c1d6d00f46b61de4da70490", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id:username",
+  //     {},
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id:username",
+    // @ts-expect-error
+    {},
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id:username");
+});
+
+test("Negative test case: 3cd3cb9b568dfc4278706a1b9a3569be", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id:username",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id:username",
+    // @ts-expect-error
+    {
+      id: 42,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42:username");
+});
+
+test("Negative test case: 77fe5fa145abed7db81f53a7bcfef672", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id:username",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id:username",
+    // @ts-expect-error
+    {
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:idJohn");
+});
+
+test("Negative test case: c2fc6a631abb5bc533ffa79ce8c424d3", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "/user/:id:username",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //       isActive: true,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "/user/:id:username",
+    {
+      id: 42,
+      username: "John",
+      // @ts-expect-error
+      isActive: true,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42John");
+});
+
+test("Negative test case: f8c0e7dfd3c704d8d2cbf87ea79eb7f3", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "username: - Software Engineer",
+  //     {},
+  //     {
+  //       prefix: "",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "username: - Software Engineer",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("username: - Software Engineer");
+});
+
+test("Negative test case: 5d64c1ca0bd22edf1fbd4ee4082851aa", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "username: - Software Engineer",
+  //     {
+  //       USER_NAME: "John",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "username: - Software Engineer",
+    {
+      // @ts-expect-error
+      USER_NAME: "John",
+    },
+    {
+      prefix: "",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("username: - Software Engineer");
+});
+
+test("Negative test case: 2799c5011a9c8c8ce494f684c2363a62", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "username: - Software Engineer",
+  //     {
+  //       username: "John",
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: ":",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "username: - Software Engineer",
+    {
+      username: "John",
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: "",
+      suffix: ":",
+    },
+  );
+
+  expect(resultText).toBe("John - Software Engineer");
+});
+
+test("Negative test case: f15576c900a23aece67b8790f75d5c5b", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "user",
+  //     {},
+  //     {
+  //       prefix: "",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "user",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("user");
+});
+
+test("Negative test case: b4395ed60e6df24fcaf8c64a73506564", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "user",
+    // @ts-expect-error
+    {
+      u: "{U}",
+    },
+    {
+      prefix: "",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("{U}ser");
+});
+
+test("Negative test case: 5301902ac4bc03f4d189138ff78aa7dd", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //       s: "<S>",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "user",
+    // @ts-expect-error
+    {
+      u: "{U}",
+      s: "<S>",
+    },
+    {
+      prefix: "",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("{U}<S>er");
+});
+
+test("Negative test case: 629e103c775ff70bf24e4ce8d895dfc6", () => {
+  // console.log(
+  //   getHash(`hydrateText(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //       s: "<S>",
+  //       e: "(E)",
+  //       r: "[R]",
+  //       x: "-X-",
+  //     },
+  //     {
+  //       prefix: "",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText(
+    "user",
+    {
+      u: "{U}",
+      s: "<S>",
+      e: "(E)",
+      r: "[R]",
+      // @ts-expect-error
+      x: "-X-",
+    },
+    {
+      prefix: "",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("{U}<S>(E)[R]");
+});
+
+test("Negative test case: 62f126044c723f6c33cf0b3e4b49cd1e", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {},
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {},
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id/:username/");
+});
+
+test("Negative test case: 9e145f684808799c252a3b9dcc83b0a8", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {
+      id: 42,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42/:username/");
+});
+
+test("Negative test case: 1d183b36f9bebd6611286603ac6ea03f", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id/John/");
+});
+
+test("Negative test case: b4b07415edd487c532b4390271acba48", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //       isActive: true,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    {
+      id: 42,
+      username: "John",
+      // @ts-expect-error
+      isActive: true,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42/John/");
+});
+
+test("Negative test case: 262e61bc664f60e8aeb5b3112da513a1", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    {
+      id: 42,
+      username: "John",
+    },
+    {
+      prefix: ":",
+      // @ts-expect-error
+      suffix: "",
+    },
+  );
+
+  expect(resultText).toBe("/user/42/John/");
+});
+
+test("Negative test case: bea0800f7db8cac5f8bc89cf890f8c98", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {},
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     } as unknown as InterpolationOptions<":", "/">,
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {},
+    {
+      prefix: ":",
+      suffix: "",
+    } as unknown as InterpolationOptions<":", "/">,
+  );
+
+  expect(resultText).toBe("/user/:id/:username/");
+});
+
+test("Negative test case: 210ad704a05d205283be9bd851ee9da8", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     } as unknown as InterpolationOptions<":", "/">,
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {
+      id: 42,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    } as unknown as InterpolationOptions<":", "/">,
+  );
+
+  expect(resultText).toBe("/user/42/:username/");
+});
+
+test("Negative test case: b7e74a2db86e541d3dad8fdb361b73d5", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     } as unknown as InterpolationOptions<":", "/">,
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    // @ts-expect-error
+    {
+      username: "John",
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    } as unknown as InterpolationOptions<":", "/">,
+  );
+
+  expect(resultText).toBe("/user/:id/John/");
+});
+
+test("Negative test case: cd001933ed729c3509d23b847c266c75", () => {
+  // console.log(
+  //   getHash(`hydrateText<"/user/:id/:username/", ":", "/">(
+  //     "/user/:id/:username/",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //       isActive: true,
+  //     },
+  //     {
+  //       prefix: ":",
+  //       suffix: "",
+  //     } as unknown as InterpolationOptions<":", "/">,
+  //   )`),
+  // );
+  const resultText = hydrateText<"/user/:id/:username/", ":", "/">(
+    "/user/:id/:username/",
+    {
+      id: 42,
+      username: "John",
+      // @ts-expect-error
+      isActive: true,
+    },
+    {
+      prefix: ":",
+      suffix: "",
+    } as unknown as InterpolationOptions<":", "/">,
+  );
+
+  expect(resultText).toBe("/user/42/John/");
+});
+
+test("Negative test case: 318796ae08e53e90f10ed2d5dfa737f6", () => {
+  // console.log(getHash(`hydrateRoute()`));
+  // @ts-expect-error
+  const resultText = hydrateRoute();
+
+  expect(resultText).toBeUndefined();
+});
+
+test("Negative test case: 4f4fd053c4fea88c9b5986fa6e78571c", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //   "/user/:id",
+  //   {},
+  // )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/:id",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("/user/:id");
+});
+
+test("Negative test case: bbd65218fd0703080e2709b24364df2b", () => {
+  // console.log(
+  //   getHash(`hydrateRoute("/user/:id", {
+  //     ID: 42,
+  //   })`),
+  // );
+  const resultText = hydrateRoute("/user/:id", {
+    // @ts-expect-error
+    ID: 42,
+  });
+
+  expect(resultText).toBe("/user/:id");
+});
+
+test("Negative test case: 6cd689e4ed7bc823683d994ebb393757", () => {
+  // console.log(
+  //   getHash(`hydrateRoute("/user/:id", {
+  //     id: 42,
+  //     username: "John",
+  //   })`),
+  // );
+  const resultText = hydrateRoute("/user/:id", {
+    id: 42,
+    // @ts-expect-error
+    username: "John",
+  });
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Negative test case: e95f207e9eaa2b21feaff941f6cd7038", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/:id:username",
+  //     {},
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/:id:username",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("/user/:id:username");
+});
+
+test("Negative test case: ea721ecccc2112a68ad21d47d240777a", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/:id:username",
+  //     {
+  //       username: "John",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/:id:username",
+    // @ts-expect-error
+    {
+      username: "John",
+    },
+  );
+
+  expect(resultText).toBe("/user/:idJohn");
+});
+
+test("Negative test case: 38bb62fb4be465bc27a6bd5c0299bb52", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/:id:username",
+  //     {
+  //       id: 42,
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/:id:username",
+    // @ts-expect-error
+    {
+      id: 42,
+    },
+  );
+
+  expect(resultText).toBe("/user/42:username");
+});
+
+test("Negative test case: 8a1ca67b89dab1a7bdbd3a1cd1b0d1ed", () => {
+  // console.log(
+  //   getHash(`hydrateRoute("/user/:id:username", {
+  //     id: 42,
+  //     username: "John",
+  //     isActive: true,
+  //   })`),
+  // );
+  const resultText = hydrateRoute("/user/:id:username", {
+    id: 42,
+    username: "John",
+    // @ts-expect-error
+    isActive: true,
+  });
+
+  expect(resultText).toBe("/user/42John");
+});
+
+test("Negative test case: 92b41b81af940608db31d005741a6c6c", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(id)",
+  //     {},
+  //     {
+  //       prefix: "(",
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(id)",
+    // @ts-expect-error
+    {},
+    {
+      prefix: "(",
+      suffix: ")",
+    },
+  );
+
+  expect(resultText).toBe("/user/(id)");
+});
+
+test("Negative test case: 823c18ebf1669a4d28a85355c563c3c3", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(id)",
+  //     {
+  //       ID: 42,
+  //     },
+  //     {
+  //       prefix: "(",
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(id)",
+    {
+      // @ts-expect-error
+      ID: 42,
+    },
+    {
+      prefix: "(",
+      suffix: ")",
+    },
+  );
+
+  expect(resultText).toBe("/user/(id)");
+});
+
+test("Negative test case: 5e49f161e48aa13c6360ca4cc3bf535d", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(id)",
+  //     {
+  //       id: 42,
+  //       username: "John",
+  //     },
+  //     {
+  //       prefix: "(",
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(id)",
+    {
+      id: 42,
+      // @ts-expect-error
+      username: "John",
+    },
+    {
+      prefix: "(",
+      suffix: ")",
+    },
+  );
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Negative test case: d7e87174c35b0a36b6edf7683372eccd", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(id",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "(",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(id",
+    {
+      id: 42,
+    },
+    // @ts-expect-error
+    {
+      prefix: "(",
+    },
+  );
+
+  expect(resultText).toBe("/user/(id");
+});
+
+test("Negative test case: dea3dc9c2eed148b9535cbdde3835a43", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/(idundefined",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       prefix: "(",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/(idundefined",
+    {
+      // @ts-expect-error
+      id: 42,
+    },
+    {
+      prefix: "(",
+    },
+  );
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Negative test case: 0715c3ceaa37e39b9b2d9ebf4c5b6c76", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/:id)",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/:id)",
+    {
+      id: 42,
+    },
+    // @ts-expect-error
+    {
+      suffix: ")",
+    },
+  );
+
+  expect(resultText).toBe("/user/:id)");
+});
+
+test("Negative test case: 844652a9cccbb162634eedc03161bcae", () => {
+  // console.log(
+  //   getHash(`hydrateRoute(
+  //     "/user/undefinedid)",
+  //     {
+  //       id: 42,
+  //     },
+  //     {
+  //       suffix: ")",
+  //     },
+  //   )`),
+  // );
+  const resultText = hydrateRoute(
+    "/user/undefinedid)",
+    {
+      id: 42,
+    },
+    // @ts-expect-error
+    {
+      suffix: ")",
+    },
+  );
+
+  expect(resultText).toBe("/user/42");
+});
+
+test("Negative test case: bf02495a5023dea7a9f35e7849b2ba1c", () => {
+  // console.log(
+  //   getHash(`replaceLetters(
+  //     "user",
+  //     {},
+  //   )`),
+  // );
+  const resultText = replaceLetters(
+    "user",
+    // @ts-expect-error
+    {},
+  );
+
+  expect(resultText).toBe("user");
+});
+
+test("Negative test case: f4460942636b17ae0beaa197dc5cb8ab", () => {
+  // console.log(
+  //   getHash(`replaceLetters(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //     },
+  //   )`),
+  // );
+  const resultText = replaceLetters(
+    "user",
+    // @ts-expect-error
+    {
+      u: "{U}",
+    },
+  );
+
+  expect(resultText).toBe("{U}ser");
+});
+
+test("Negative test case: e90c03a47d7cbc56fb2f5dd44bebe162", () => {
+  // console.log(
+  //   getHash(`replaceLetters(
+  //     "user",
+  //     {
+  //       u: "{U}",
+  //       s: "<S>",
+  //     },
+  //   )`),
+  // );
+  const resultText = replaceLetters(
+    "user",
+    // @ts-expect-error
+    {
+      u: "{U}",
+      s: "<S>",
+    },
+  );
+
+  expect(resultText).toBe("{U}<S>er");
+});
+
+test("Negative test case: 6001dba4f00a338fc6409af6788b0879", () => {
+  // console.log(
+  //   getHash(`replaceLetters("user", {
+  //     u: "{U}",
+  //     s: "<S>",
+  //     e: "(E)",
+  //     r: "[R]",
+  //     x: "-X-",
+  //   })`),
+  // );
+  const resultText = replaceLetters("user", {
+    u: "{U}",
+    s: "<S>",
+    e: "(E)",
+    r: "[R]",
+    // @ts-expect-error
+    x: "-X-",
+  });
+
+  expect(resultText).toBe("{U}<S>(E)[R]");
 });

--- a/src/tests/index.types.ts
+++ b/src/tests/index.types.ts
@@ -1,0 +1,240 @@
+import { configureHydrateText, hydrateText } from "..";
+import { InterpolationOptions } from "../types";
+
+// Test Id: e3d1bd7920d571fae01eb16c3b8343ba
+hydrateText("");
+
+// Test Id: 18d6dbe5774751098a4a74c590ef53c0
+hydrateText("Hello World!");
+
+// Test Id: 4260b34d10b016b41c1b7509cbe699fd
+hydrateText("Hello, {username}!");
+
+// Test Id: 2af2fc130be13f625c9c5adafd808471
+hydrateText("", {});
+
+// Test Id: c4bb40eefc35e88d5779a86a99560386
+hydrateText("Hello World!", {});
+
+// Test Id: 42301541eb3fc4573221705d2113b799
+hydrateText("Hello, {username}!", {
+  username: "John",
+});
+
+// Test Id: 383c38f885d84ebd652223325669afd1
+hydrateText("{firstName} {lastName}", {
+  firstName: "John",
+  lastName: "Doe",
+});
+
+// Test Id: 4fadf44d831fc988cf92fa78c54e8b5e
+hydrateText("Active: {isActive}", {
+  isActive: true,
+});
+
+// Test Id: b3178c3166956e50643e4267c312607e
+hydrateText("Seconds: {seconds}", {
+  seconds: 1_000_000,
+});
+
+// Test Id: 4e55ba820ff0a4c8e2a7c925e7693c2b
+hydrateText("milliseconds: {milliseconds}", {
+  milliseconds: BigInt(9007199254740991),
+});
+
+// Test Id: af9b1b362e6dee5ed69f10bb7e397c95
+hydrateText("Hello, {{username}}!", {
+  username: "John",
+});
+
+// Test Id: 18cd8d6e9f8325289789633dfe77000f
+hydrateText(
+  "Hello, {username}!",
+  {
+    username: "John",
+  },
+  {
+    prefix: "{",
+    suffix: "}",
+  },
+);
+
+// Test Id: 01f2345edad7d94b6f753581a2b17a27
+hydrateText(
+  "Hello, {{username}}!",
+  {
+    username: "John",
+  },
+  {
+    prefix: "{{",
+    suffix: "}}",
+  },
+);
+
+// Test Id: 4a43c157fab840b304b4748a07267f6b
+hydrateText(
+  "Hello, ${username}!",
+  {
+    username: "John",
+  },
+  {
+    prefix: "${",
+    suffix: "}",
+  },
+);
+
+// Test Id: ab65a82ede035969c3b775a4c12c4532
+hydrateText(
+  ":firstName: :lastName:",
+  {
+    firstName: "John",
+    lastName: "Doe",
+  },
+  {
+    prefix: ":",
+    suffix: ":",
+  },
+);
+
+// Test Id: 92b4b1b542a73f57476f371932510d1a
+hydrateText(
+  "/user/:id",
+  {
+    id: 42,
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: c14763e95536731399382dee040a5602
+hydrateText(
+  "/user/:id:username",
+  {
+    id: 42,
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  },
+);
+
+// Test Id: 7fa77b7792d13b8567c8e9a6c82195dd
+hydrateText(
+  "username: - Software Engineer",
+  {
+    username: "John",
+  },
+  {
+    prefix: "",
+    suffix: ":",
+  },
+);
+
+// Test Id: 78a37c77100f73d67498ae4ff83ddf53
+hydrateText(
+  "user",
+  {
+    u: "{U}",
+    s: "<S>",
+    e: "(E)",
+    r: "[R]",
+  },
+  {
+    prefix: "",
+    suffix: "",
+  },
+);
+
+// Test Id: 5eaa48bee5ae430cbab0ff3746c27a53
+/*
+  If we set `suffix` in the interpolation options (the 3d argument) as "/",
+  this character will be replaced. In this case, it is necessary to re-define
+  the function's types to get the correct variables names and use type assertion
+  on interpolation options object to fix inconsistency error.
+*/
+hydrateText<"/user/:id/:username/", ":", "/">(
+  "/user/:id/:username/",
+  {
+    id: 42,
+    username: "John",
+  },
+  {
+    prefix: ":",
+    suffix: "",
+  } as unknown as InterpolationOptions<":", "/">,
+);
+
+// Test Id: f73fa2573b43438a2ac9a52706e2604b
+hydrateText("Hello World!" as string);
+
+// Test Id: 707af50942d29b5c46fe7d0c0b381b3c
+hydrateText("Hello World!" as string, {});
+
+// Test Id: e37d01f00d8432804eeaa6add2cc7a9a
+hydrateText("Hello World!" as string, {
+  username: "John",
+});
+
+// Test Id: bf580c9c905ee5f255a28e6b850347f9
+hydrateText("Hello, {username}!" as string, {
+  username: "John",
+});
+
+const hydrateRoute = configureHydrateText({
+  prefix: ":",
+  suffix: "",
+});
+
+// Test Id: cdcdac2c1b868bc728472cd6cbba271f
+hydrateRoute("");
+
+// Test Id: d666a945c62ffbb4dfbefa886e1f9b7d
+hydrateRoute("Hello World!");
+
+// Test Id: 176fa7cbde3554852920b8117ffd06ec
+hydrateRoute("Hello, {username}!");
+
+// Test Id: df846302df158f3abb4a2cdb8ab14af9
+hydrateRoute("", {});
+
+// Test Id: 6e3983ff1c1769fc3fce68ad636ed0e1
+hydrateRoute("Hello World!", {});
+
+// Test Id: 387e00c55433a77cb30054261f8dbd70
+hydrateRoute("/user/:id");
+
+// Test Id: e39e3bddb6906f26f5e28be34a529d50
+hydrateRoute("/user/:id", {
+  id: 42,
+});
+
+// Test Id: 4fc02ff80bd4bb296c9a06506040314a
+hydrateRoute(
+  "/user/(id)",
+  {
+    id: 42,
+  },
+  {
+    prefix: "(",
+    suffix: ")",
+  },
+);
+
+const replaceLetters = configureHydrateText({
+  prefix: "",
+  suffix: "",
+});
+
+// Test Id: a50d6c6a7ee526b764bfd112c69ec773
+replaceLetters("user", {
+  u: "{U}",
+  s: "<S>",
+  e: "(E)",
+  r: "[R]",
+});
+
+// Test Id: 848097af194354e7e59c3a06a33f8844
+replaceLetters("some very, very long text");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,28 +1,84 @@
-type ValueType = string | number | boolean;
+type ValueType = string | boolean | number | bigint;
 
-type Variables = Record<string, ValueType>;
+type GetVariables<
+  Text extends string,
+  Prefix extends string,
+  Suffix extends string,
+> = string extends Text
+  ? string
+  : Prefix extends ""
+  ? Suffix extends ""
+    ? // Prefix === "", Suffix === ""
+      Text extends `${infer Letter}${infer Rest}`
+      ? Letter | GetVariables<Rest, Prefix, Suffix>
+      : never
+    : // Prefix === "", Suffix !== ""
+    Text extends `${infer Variable}${Suffix}${infer Rest}`
+    ? Variable | GetVariables<Rest, Prefix, Suffix>
+    : never
+  : Suffix extends ""
+  ? // Prefix !== "", Suffix === ""
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    Text extends `${infer _Start}${Prefix}${infer Variable}`
+    ? Variable extends `${infer _Variable}${Prefix}${infer Rest}`
+      ? _Variable | GetVariables<`${Prefix}${Rest}`, Prefix, Suffix>
+      : Variable
+    : never
+  : // Prefix !== "", Suffix !== ""
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Text extends `${infer _Start}${Prefix}${infer Variable}${Suffix}${infer Rest}`
+  ? Variable extends `${infer _Start}${Prefix}${infer _Variable}`
+    ? GetVariables<
+        `${_Start}${Prefix}${_Variable}${Suffix}${Rest}`,
+        Prefix,
+        Suffix
+      >
+    : Variable | GetVariables<Rest, Prefix, Suffix>
+  : never;
 
-interface InterpolationOptions {
-  prefix?: string;
-  suffix?: string;
+interface InterpolationOptions<Prefix extends string, Suffix extends string> {
+  prefix: Prefix;
+  suffix: Suffix;
 }
 
+type DefaultPrefix = "{";
+
+type DefaultSuffix = "}";
+
 interface HydrateText {
-  (
-    text: string,
-    variables?: Variables,
-    interpolationOptions?: InterpolationOptions,
+  <
+    Text extends string,
+    Prefix extends string = DefaultPrefix,
+    Suffix extends string = DefaultSuffix,
+  >(
+    text: Text,
+    variables?: Record<GetVariables<Text, Prefix, Suffix>, ValueType>,
+    interpolationOptions?: InterpolationOptions<Prefix, Suffix>,
   ): string;
 }
 
 interface ConfigureHydrateText {
-  (interpolationOptions?: InterpolationOptions): HydrateText;
+  <
+    _Prefix extends string = DefaultPrefix,
+    _Suffix extends string = DefaultSuffix,
+  >(
+    interpolationOptions: InterpolationOptions<_Prefix, _Suffix>,
+  ): <
+    Text extends string,
+    Prefix extends string = _Prefix,
+    Suffix extends string = _Suffix,
+  >(
+    text: Text,
+    variables?: Record<GetVariables<Text, Prefix, Suffix>, ValueType>,
+    interpolationOptions?: InterpolationOptions<Prefix, Suffix>,
+  ) => string;
 }
 
 export type {
   ConfigureHydrateText,
+  DefaultPrefix,
+  DefaultSuffix,
   HydrateText,
   InterpolationOptions,
   ValueType,
-  Variables,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,4 +22,13 @@ const escapeRegExp = (value?: string): string => {
   return string.replace(reRegExpChar, "\\$&");
 };
 
-export { escapeRegExp };
+/*
+  Source: https://github.com/lodash/lodash/blob/master/isUndefined.js
+
+  Checks if `value` is `undefined`.
+*/
+const isUndefined = (value: unknown): value is undefined => {
+  return value === undefined;
+};
+
+export { escapeRegExp, isUndefined };

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -7,7 +7,7 @@
     "outDir": "./dist/esm"
   },
   "exclude": [
-    "**/*.test.ts",
+    "**/tests/*.ts",
     /*
       Fixes error TS5055 ("Cannot write file '.../dist/types/....d.ts' because
       it would overwrite input file").

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "noEmit": true,
     "strict": true,
     "target": "ES2015",
-    "types": ["jest"]
+    "types": ["jest", "node"]
   }
 }

--- a/tsconfig.tslint.json
+++ b/tsconfig.tslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/tests/index.errors.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -548,9 +548,9 @@
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz#94c23db18ee4653e129abd26fb06f870ac9e1ee2"
-  integrity sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
@@ -575,9 +575,9 @@
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
-  version "7.1.14"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
-  integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
+  version "7.1.15"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
+  integrity sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -586,24 +586,24 @@
     "@types/babel__traverse" "*"
 
 "@types/babel__generator@*":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.2.tgz#f3d71178e187858f7c45e30380f8f1b7415a12d8"
-  integrity sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.3.tgz#f456b4b2ce79137f768aa130d2423d2f0ccfaba5"
+  integrity sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==
   dependencies:
     "@babel/types" "^7.0.0"
 
 "@types/babel__template@*":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.0.tgz#0c888dd70b3ee9eebb6e4f200e809da0076262be"
-  integrity sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.1.tgz#3d1a48fd9d6c0edfd56f2ff578daed48f36c8969"
+  integrity sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.0.tgz#a34277cf8acbd3185ea74129e1f100491eb1da7f"
-  integrity sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.2.tgz#ffcd470bbb3f8bf30481678fb5502278ca833a43"
+  integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -633,38 +633,38 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.23":
-  version "26.0.23"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
-  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+"@types/jest@^26.0.24":
+  version "26.0.24"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
+  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
 "@types/json-schema@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
-  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
+  integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
-"@types/json5@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
-  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@types/node@*":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
-  integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
+"@types/node@*", "@types/node@^16.3.1":
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.1.tgz#24691fa2b0c3ec8c0d34bfcfd495edac5593ebb4"
+  integrity sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==
 
 "@types/prettier@^2.1.5":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.1.tgz#54dd88bdc7f49958329666af3779561e47d5dab3"
-  integrity sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
+  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/unist@^2.0.0":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.5.tgz#fdd299f23205c3455af88ce618dd65c14cb73e22"
+  integrity sha512-wnra4Vw9dopnuybR6HBywJ/URYpYrKLoepBTEtgfJup8Ahoi2zJECPP2cwiXp7btTvOT2CULv87aQRA4eZSP6g==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -685,73 +685,73 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz#c045e440196ae45464e08e20c38aff5c3a825947"
-  integrity sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==
+"@typescript-eslint/eslint-plugin@^4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz#36cdcd9ca6f9e5cb49b9f61b970b1976708d084b"
+  integrity sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.28.1"
-    "@typescript-eslint/scope-manager" "4.28.1"
+    "@typescript-eslint/experimental-utils" "4.28.3"
+    "@typescript-eslint/scope-manager" "4.28.3"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz#3869489dcca3c18523c46018b8996e15948dbadc"
-  integrity sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==
+"@typescript-eslint/experimental-utils@4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz#976f8c1191b37105fd06658ed57ddfee4be361ca"
+  integrity sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
+    "@typescript-eslint/scope-manager" "4.28.3"
+    "@typescript-eslint/types" "4.28.3"
+    "@typescript-eslint/typescript-estree" "4.28.3"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.1.tgz#5181b81658414f47291452c15bf6cd44a32f85bd"
-  integrity sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==
+"@typescript-eslint/parser@^4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.3.tgz#95f1d475c08268edffdcb2779993c488b6434b44"
+  integrity sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
+    "@typescript-eslint/scope-manager" "4.28.3"
+    "@typescript-eslint/types" "4.28.3"
+    "@typescript-eslint/typescript-estree" "4.28.3"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
-  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
+"@typescript-eslint/scope-manager@4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz#c32ad4491b3726db1ba34030b59ea922c214e371"
+  integrity sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
+    "@typescript-eslint/types" "4.28.3"
+    "@typescript-eslint/visitor-keys" "4.28.3"
 
-"@typescript-eslint/types@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
-  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
+"@typescript-eslint/types@4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.3.tgz#8fffd436a3bada422c2c1da56060a0566a9506c7"
+  integrity sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==
 
-"@typescript-eslint/typescript-estree@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
-  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
+"@typescript-eslint/typescript-estree@4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz#253d7088100b2a38aefe3c8dd7bd1f8232ec46fb"
+  integrity sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
+    "@typescript-eslint/types" "4.28.3"
+    "@typescript-eslint/visitor-keys" "4.28.3"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
-  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
+"@typescript-eslint/visitor-keys@4.28.3":
+  version "4.28.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz#26ac91e84b23529968361045829da80a4e5251c4"
+  integrity sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/types" "4.28.3"
     eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3, abab@^2.0.5:
@@ -768,9 +768,9 @@ acorn-globals@^6.0.0:
     acorn-walk "^7.1.1"
 
 acorn-jsx@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^7.1.1:
   version "7.2.0"
@@ -805,9 +805,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720"
-  integrity sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.1.tgz#ae65764bf1edde8cd861281cda5057852364a295"
+  integrity sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1040,9 +1040,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001242"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz#04201627abcd60dc89211f22cbe2347306cda46b"
-  integrity sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==
+  version "1.0.30001244"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001244.tgz#a6dc49ad5fa02d81d04373ec3f5ceabc3da06abf"
+  integrity sha512-Wb4UFZPkPoJoKKVfELPWytRzpemjP/s0pe22NriANru1NoI+5bGNxzKtk7edYL8rmCWTfQO8eRiF0pn1Dqzx7Q==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1065,6 +1065,17 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+check-dts@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/check-dts/-/check-dts-0.5.3.tgz#061ff8f00d44ea445185c811d960320c653ee7a7"
+  integrity sha512-G32Wfg99PeiqsZkGY0S0LqlxvMHcvRWvoLRIrA5nASNCiD6BsCleTwAP7hggUEfhg40WeRZW5Qb+pc/RjKU2lQ==
+  dependencies:
+    colorette "^1.2.2"
+    globby "^11.0.4"
+    mico-spinner "^1.1.1"
+    typescript "^4.3.5"
+    vfile-location "^4.0.1"
 
 ci-info@^3.1.1:
   version "3.2.0"
@@ -1275,9 +1286,9 @@ domexception@^2.0.1:
     webidl-conversions "^5.0.0"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.766"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz#2fd14a4e54f77665872f4e23fcf4968e83638220"
-  integrity sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==
+  version "1.3.774"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.774.tgz#4d6661a23119e35151646c9543b346bb3beca423"
+  integrity sha512-Fggh17Q1yyv1uMzq8Qn1Ci58P50qcRXMXd2MBcB9sxo6rJxjUutWcNw8uCm3gFWMdcblBO6mDT5HzX/RVRRECA==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -1579,9 +1590,9 @@ fast-diff@^1.1.2:
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"
-  integrity sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1600,9 +1611,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastq@^1.6.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
-  integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.1.tgz#5d8175aae17db61947f8b162cfc7f63264d22807"
+  integrity sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==
   dependencies:
     reusify "^1.0.4"
 
@@ -1651,9 +1662,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.0.tgz#da07fb8808050aba6fdeac2294542e5043583f05"
-  integrity sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.1.tgz#bbef080d95fca6709362c73044a1634f7c6e7d05"
+  integrity sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -1738,13 +1749,13 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
-  version "13.9.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.9.0.tgz#4bf2bf635b334a173fb1daf7c5e6b218ecdc06cb"
-  integrity sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==
+  version "13.10.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.10.0.tgz#60ba56c3ac2ca845cfbf4faeca727ad9dd204676"
+  integrity sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.3:
+globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -1895,6 +1906,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
 
+is-buffer@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
@@ -1908,9 +1924,9 @@ is-ci@^3.0.0:
     ci-info "^3.1.1"
 
 is-core-module@^2.2.0, is-core-module@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
-  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
+  integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
   dependencies:
     has "^1.0.3"
 
@@ -2532,19 +2548,12 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json5@2.x, json5@^2.1.2:
+json5@2.x, json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -2653,6 +2662,13 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+mico-spinner@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mico-spinner/-/mico-spinner-1.1.1.tgz#b904cf4dc1ae247d9bff24b969d8bcbb08371f5d"
+  integrity sha512-b9F3Qx9l6fO141+FbR9hqRUJ15p4bGVsqgXiO/noxxXZmN+hYZVCuWd4LEubadrVkw0eIYAJDXWo0ZYGoLrmfg==
+  dependencies:
+    colorette "^1.2.2"
+
 micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
@@ -2758,9 +2774,9 @@ nwsapi@^2.2.0:
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
 object-inspect@^1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
-  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -3427,12 +3443,11 @@ ts-jest@^27.0.3:
     yargs-parser "20.x"
 
 tsconfig-paths@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
-  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz#79ae67a68c15289fdf5c51cb74f397522d795ed7"
+  integrity sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==
   dependencies:
-    "@types/json5" "^0.0.29"
-    json5 "^1.0.1"
+    json5 "^2.2.0"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
@@ -3499,6 +3514,13 @@ unbox-primitive@^1.0.1:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
+unist-util-stringify-position@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz#d517d2883d74d0daa0b565adc3d10a02b4a8cde9"
+  integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -3532,6 +3554,32 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vfile-location@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-4.0.1.tgz#06f2b9244a3565bef91f099359486a08b10d3a95"
+  integrity sha512-JDxPlTbZrZCQXogGheBHjbRWjESSPEak770XwWPfw5mTc1v1nWGLB/apzZxsx8a0SJVfF8HK8ql8RD308vXRUw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    vfile "^5.0.0"
+
+vfile-message@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.0.1.tgz#b9bcf87cb5525e61777e0c6df07e816a577588a3"
+  integrity sha512-gYmSHcZZUEtYpTmaWaFJwsuUD70/rTY4v09COp8TGtOkix6gGxb/a8iTQByIY9ciTk9GwAwIXd/J9OPfM4Bvaw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
+vfile@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.0.2.tgz#57773d1d91478b027632c23afab58ec3590344f0"
+  integrity sha512-5cV+K7tX83MT3bievROc+7AvHv0GXDB0zqbrTjbOe+HRbkzvY4EP+wS3IR77kUBCoWFMdG9py18t0sesPtQ1Rw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -3633,9 +3681,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.4.5:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
-  integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes #25 

## Breaking changes
* Make `interpolationOptions` in `ConfigureHydrateText` required
* Make `prefix` and `suffix` in `InterpolationOptions` required

## Minor changes
* Add strong type checking for the variables object
* Add `BigInt` support

## Chore
* Add `check-dts` library
* Define correct and incorrect usage examples
* Re-write all the tests
* Update libraries
* Change the library's version to 4.0.0